### PR TITLE
Fix link to wikipedia "ROUGE (metric)" article

### DIFF
--- a/templates/content/choosing-ml-models/ai-guide-pick-a-model-test-a-model.ipynb
+++ b/templates/content/choosing-ml-models/ai-guide-pick-a-model-test-a-model.ipynb
@@ -204,7 +204,7 @@
         "\n",
         "Now we're in business! This page contains a significant amount of new information.\n",
         "\n",
-        "There are mentions of three new terms: ROUGE-1, ROUGE-2 and ROUGE-L. These are the metrics that are used to [measure summarization performance](https://en.wikipedia.org/wiki/ROUGE_(metric)).\n",
+        "There are mentions of three new terms: ROUGE-1, ROUGE-2 and ROUGE-L. These are the metrics that are used to [measure summarization performance](https://en.wikipedia.org/wiki/ROUGE_%28metric%29).\n",
         "\n",
         "There are also a list of models and their scores on these three metrics - this is exactly what we're looking for.\n",
         "\n",


### PR DESCRIPTION
Right now the link goes to https://en.wikipedia.org/wiki/ROUGE_(metric which is a 404 page.

⚠️ I tried for probably around 30 minutes but I was not able to build this and see if it actually renders a better link. So someone should build this and make sure it works right.

The build error I got was:

> KeyError: 'template_paths'

I have no idea how to fix that. I assume that I may have gotten a too-new jupyter package or something. 🤷 